### PR TITLE
Fix what commands to run with bower

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,8 +168,7 @@
                             <goal>bower</goal>
                         </goals>
                         <configuration>
-                            <arguments>install</arguments>
-                            <arguments>--allow-root</arguments>
+                            <arguments>install --allow-root</arguments>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
This was breaking the docker build command. It appears that the maven frontend plugin runs in sudo mode.
