### PR TITLE
Adverse Event descriptions

### DIFF
--- a/src/main/java/com/nicusa/PersistenceConfiguration.java
+++ b/src/main/java/com/nicusa/PersistenceConfiguration.java
@@ -40,7 +40,7 @@ public class PersistenceConfiguration {
   @Bean
   public PlatformTransactionManager transactionManager() {
       JpaTransactionManager transactionManager = new JpaTransactionManager();
-      transactionManager.setEntityManagerFactory(entityManagerFactory().getObject() );
+//      transactionManager.setEntityManagerFactory(entityManagerFactory().getObject() );
     return transactionManager;
   }
 

--- a/src/main/java/com/nicusa/PersistenceConfiguration.java
+++ b/src/main/java/com/nicusa/PersistenceConfiguration.java
@@ -1,5 +1,8 @@
 package com.nicusa;
 
+import javax.persistence.SharedCacheMode;
+import javax.sql.DataSource;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -11,18 +14,16 @@ import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.Database;
 import org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.support.TransactionTemplate;
-
-import javax.persistence.SharedCacheMode;
-import javax.sql.DataSource;
-import java.sql.SQLException;
 
 @Configuration
 @Profile("local")
+@EnableTransactionManagement
 public class PersistenceConfiguration {
 
   @Bean
-  public DataSource dataSource() throws SQLException {
+  public DataSource dataSource()  {
     EmbeddedDatabaseBuilder builder = new EmbeddedDatabaseBuilder();
     return builder.setType(EmbeddedDatabaseType.HSQL).build();
   }
@@ -38,7 +39,9 @@ public class PersistenceConfiguration {
 
   @Bean
   public PlatformTransactionManager transactionManager() {
-    return new JpaTransactionManager();
+      JpaTransactionManager transactionManager = new JpaTransactionManager();
+      transactionManager.setEntityManagerFactory(entityManagerFactory().getObject() );
+    return transactionManager;
   }
 
 
@@ -48,7 +51,7 @@ public class PersistenceConfiguration {
   }
 
   @Bean
-  public LocalContainerEntityManagerFactoryBean entityManagerFactory() throws SQLException {
+  public LocalContainerEntityManagerFactoryBean entityManagerFactory()  {
     LocalContainerEntityManagerFactoryBean factory = new LocalContainerEntityManagerFactoryBean();
     factory.setJpaVendorAdapter(vendorAdapter());
     factory.setSharedCacheMode(SharedCacheMode.NONE);

--- a/src/main/java/com/nicusa/UiApplication.java
+++ b/src/main/java/com/nicusa/UiApplication.java
@@ -1,33 +1,22 @@
 package com.nicusa;
 
-import java.io.File;
 import java.io.FileNotFoundException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
 import org.springframework.boot.context.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.PropertySource;
-import org.springframework.context.annotation.PropertySources;
-import org.springframework.core.annotation.Order;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.util.ResourceUtils;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootApplication
@@ -47,12 +36,24 @@ public class UiApplication {
 
   @Value("${keystore.alias:}")
   private String keystoreAlias;
-
-
+  
   public static void main(String[] args) {
     SpringApplication.run(UiApplication.class, args);
   }
 
+  @Bean
+  public DocumentBuilder documentBuilder() throws ParserConfigurationException
+  {
+      DocumentBuilder builder = null;
+      builder = documentBuilderFactory().newDocumentBuilder();
+      return builder;
+  }
+  
+  public DocumentBuilderFactory documentBuilderFactory()
+  {
+      return DocumentBuilderFactory.newInstance();
+  }
+  
   @Bean
   public EmbeddedServletContainerCustomizer containerCustomizer() throws FileNotFoundException
   {

--- a/src/main/java/com/nicusa/UiApplication.java
+++ b/src/main/java/com/nicusa/UiApplication.java
@@ -1,5 +1,7 @@
 package com.nicusa;
 
+import com.nicusa.util.HttpSlurper;
+
 import java.io.FileNotFoundException;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -8,14 +10,24 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
 import org.springframework.boot.context.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.util.ResourceUtils;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -36,7 +48,8 @@ public class UiApplication {
 
   @Value("${keystore.alias:}")
   private String keystoreAlias;
-  
+
+
   public static void main(String[] args) {
     SpringApplication.run(UiApplication.class, args);
   }
@@ -47,6 +60,12 @@ public class UiApplication {
       DocumentBuilder builder = null;
       builder = documentBuilderFactory().newDocumentBuilder();
       return builder;
+  }
+  
+  @Bean 
+  public HttpSlurper slurper()
+  {
+      return new HttpSlurper();
   }
   
   public DocumentBuilderFactory documentBuilderFactory()

--- a/src/main/java/com/nicusa/domain/AdverseEffectDescription.java
+++ b/src/main/java/com/nicusa/domain/AdverseEffectDescription.java
@@ -1,5 +1,6 @@
 package com.nicusa.domain;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -32,6 +33,7 @@ public class AdverseEffectDescription
         this.id = id;
     }
 
+    @Column(name="FDA_NAME", length=50)
     public String getFdaName ()
     {
         return fdaName;
@@ -42,6 +44,7 @@ public class AdverseEffectDescription
         this.fdaName = fdaName;
     }
 
+    @Column(name="DESC", length=512)
     public String getDescription ()
     {
         return description;

--- a/src/main/java/com/nicusa/domain/AdverseEffectDescription.java
+++ b/src/main/java/com/nicusa/domain/AdverseEffectDescription.java
@@ -1,0 +1,56 @@
+package com.nicusa.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+
+@Entity
+public class AdverseEffectDescription
+{
+    public static final String SEQUENCE_NAME = "ADVERSE_EVENT_DESC_SEQ";
+    
+    private Long id;
+    private String fdaName;
+    private String description;
+    
+    public AdverseEffectDescription()
+    {
+    }
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @SequenceGenerator(name = SEQUENCE_NAME, allocationSize = 1)
+    public Long getId ()
+    {
+        return id;
+    }
+
+    public void setId (Long id)
+    {
+        this.id = id;
+    }
+
+    public String getFdaName ()
+    {
+        return fdaName;
+    }
+
+    public void setFdaName (String fdaName)
+    {
+        this.fdaName = fdaName;
+    }
+
+    public String getDescription ()
+    {
+        return description;
+    }
+
+    public void setDescription (String description)
+    {
+        this.description = description;
+    }
+    
+
+}

--- a/src/main/java/com/nicusa/service/AdverseEffectService.java
+++ b/src/main/java/com/nicusa/service/AdverseEffectService.java
@@ -1,0 +1,115 @@
+package com.nicusa.service;
+
+import com.nicusa.domain.AdverseEffectDescription;
+import com.nicusa.util.HttpSlurper;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLEncoder;
+import java.util.Collection;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+import javax.xml.parsers.DocumentBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+@Service(AdverseEffectService.NAME)
+public class AdverseEffectService
+{
+    Logger log = LoggerFactory.getLogger(AdverseEffectService.class);
+    public static final String NAME = "adverseEffectService";
+    
+    @Value("${merriam.webster.key:21a8b25b-2e1b-4969-9a28-d522f5782b26}")
+    private String merriamWebsterKey;
+
+    @PersistenceContext
+    EntityManager entityManager;
+    
+    @Autowired
+    DocumentBuilder documentBuilder;
+    
+    @Autowired
+    @Value("${meriam.webster.key:}")
+    private String meriamWebsterKey;
+    
+    @Autowired
+    @Value("${meriam.webster.medical.url:http://www.dictionaryapi.com/api/v1/references/medical/xml/")
+    private String meriamWebsterUrl;
+    
+
+    public String findEffectDescription(String effectName) throws IOException {
+        String retval = null;
+        
+        AdverseEffectDescription desc = findEventDescriptionInCache(effectName);
+        if(desc == null)
+        {
+            desc = retrieveDescriptionFromDictionary(effectName);
+        }
+        assert(desc != null);
+        return desc.getDescription();
+    }
+    
+    @Transactional
+    private AdverseEffectDescription retrieveDescriptionFromDictionary(String effectName) throws IOException
+    {
+        AdverseEffectDescription desc = new AdverseEffectDescription();
+        try {
+            String eval = URLEncoder.encode(effectName, "UTF-8");
+            HttpSlurper slurp = new HttpSlurper();
+            String s = slurp.getData(meriamWebsterUrl+eval+"?key="+merriamWebsterKey);
+            String definition = null;
+
+            definition = parseDefinition(s);
+            
+            desc.setFdaName(effectName);
+            desc.setDescription(definition);
+            entityManager.persist(desc);
+
+        } catch (IOException | SAXException ioe)
+        {
+            log.warn("Unable to parse definition for "+effectName);
+        }
+        return desc;
+    }
+    
+    private AdverseEffectDescription findEventDescriptionInCache(String fdaEventName) {
+        AdverseEffectDescription retval = null;
+        Query q = entityManager.createQuery("SELECT a FROM AdverseEffectDescription a WHERE a.fdaName = :fdaName");
+        Collection<AdverseEffectDescription> aeDescriptions = q.getResultList();
+        if(aeDescriptions.size() > 0)
+        {
+            retval = (AdverseEffectDescription)aeDescriptions.toArray()[0];
+        }
+        return retval;
+    }
+    
+    private String parseDefinition(String xml) throws IOException, SAXException
+    {
+        String retval = null;
+        InputStream is = new ByteArrayInputStream(xml.getBytes());
+        
+        Document dom = documentBuilder.parse(is);
+        Element root = dom.getDocumentElement();
+        NodeList dts = root.getElementsByTagName("dt");
+        if(dts != null && dts.getLength() > 0)
+        {
+            Element dt = (Element)dts.item(0);
+            retval = dt.getTextContent();
+        }
+        return retval;
+    }
+    
+
+}

--- a/src/main/java/com/nicusa/service/AdverseEffectService.java
+++ b/src/main/java/com/nicusa/service/AdverseEffectService.java
@@ -27,6 +27,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 @Service(AdverseEffectService.NAME)
+@Transactional
 public class AdverseEffectService
 {
     Logger log = LoggerFactory.getLogger(AdverseEffectService.class);
@@ -76,7 +77,7 @@ public class AdverseEffectService
                 definition = parseDefinition(s);
                 if(definition != null)
                 {
-                    desc.setDescription(definition);
+                    desc.setDescription(definition.substring(0, definition.length() > 512 ? 512 : definition.length()));
                 }
                 
                 entityManager.persist(desc);
@@ -84,10 +85,7 @@ public class AdverseEffectService
         } catch (IOException | SAXException ioe)
         {
             log.warn("Unable to parse definition for "+effectName);
-        } catch (TransactionRequiredException tre)
-        {
-            log.warn("unable to cache adverse effect description");
-        }
+        } 
         return desc;
     }
     

--- a/src/main/java/com/nicusa/service/AdverseEffectService.java
+++ b/src/main/java/com/nicusa/service/AdverseEffectService.java
@@ -41,12 +41,15 @@ public class AdverseEffectService
     DocumentBuilder documentBuilder;
     
     @Autowired
+    HttpSlurper slurper;
+    
+    @Autowired
     @Value("${merriam.webster.key:}")
-    private String merriamWebsterKey;
+    String merriamWebsterKey;
 
     @Autowired
     @Value("${meriam.webster.medical.url:http://www.dictionaryapi.com/api/v1/references/medical/xml/}")
-    private String meriamWebsterUrl;
+    String meriamWebsterUrl;
     
 
     public String findEffectDescription(String effectName) throws IOException {
@@ -70,8 +73,7 @@ public class AdverseEffectService
             if(merriamWebsterKey != null && merriamWebsterKey.length() > 0)
             {
                 String eval = URLEncoder.encode(effectName, "UTF-8");
-                HttpSlurper slurp = new HttpSlurper();
-                String s = slurp.getData(meriamWebsterUrl+eval+"?key="+merriamWebsterKey);
+                String s = slurper.getData(meriamWebsterUrl+eval+"?key="+merriamWebsterKey);
                 String definition = null;
     
                 definition = parseDefinition(s);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,4 @@ drug.most.recent.recalls.total.limit=50
 drug.recalls.unii.total.limit=99
 api.fda.keys=
 spring.profiles.active=local
+merriam.webster.key=432470b7-9bd2-4261-9611-2816b0d774cf

--- a/src/test/java/com/nicusa/TestConfig.java
+++ b/src/test/java/com/nicusa/TestConfig.java
@@ -3,9 +3,11 @@ package com.nicusa;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 @Configuration
 @ComponentScan(basePackages = {"com.nicusa"})
+@Import(PersistenceConfiguration.class)
 public class TestConfig
 {
 
@@ -20,4 +22,11 @@ public class TestConfig
     {
         return "http://ajax.googleapis.com/ajax/services/feed/load?v=1.0&num=10&q=";
     }
+    
+    @Bean
+    public String fdaDrugEventRSSurl()
+    {
+        return "https://api.fda.gov/drug/event.json";
+    }
+
 }

--- a/src/test/java/com/nicusa/controller/EventControllerTest.java
+++ b/src/test/java/com/nicusa/controller/EventControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.nicusa.service.AdverseEffectService;
 import com.nicusa.util.ApiKey;
 
 import java.io.IOException;
@@ -44,6 +45,9 @@ public class EventControllerTest {
   @Test
   public void testSearch () throws IOException {
     EventController event = new EventController();
+    AdverseEffectService aeService = mock(AdverseEffectService.class);
+    event.adverseEffectService = aeService;
+    when(aeService.findEffectDescription(anyString())).thenReturn("diarrhoea");
     event.rest = mock( RestTemplate.class );
     event.apiKey = new ApiKey();
     final String res = "{\"meta\":{\"disclaimer\":\"openFDA is a beta research project and not for clinical use. While we make every effort to ensure that data is accurate, you should assume all results are unvalidated.\",\"license\":\"http://open.fda.gov/license\",\"last_updated\": \"2015-01-21\"},\"results\":[{\"term\":\"PAIN\",\"count\": 584  },{\"term\": \"DIARRHOEA\",\"count\":543},{\"term\": \"NAUSEA\",\"count\": 481},{\"term\":\"ANXIETY\",\"count\": 417}]}";
@@ -60,6 +64,7 @@ public class EventControllerTest {
     assertTrue( results.contains( "DIARRHOEA" ));
     assertTrue( results.contains( "481" ));
     assertTrue( !results.contains( "ANXIETY" ));
+    assertTrue( results.contains( "diarrhoea"));
   }
   
   

--- a/src/test/java/com/nicusa/controller/EventControllerTest.java
+++ b/src/test/java/com/nicusa/controller/EventControllerTest.java
@@ -1,22 +1,24 @@
 package com.nicusa.controller;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.nicusa.util.ApiKey;
-import com.nicusa.util.HttpSlurper;
+
+import java.io.IOException;
+import java.util.Map;
 
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.web.client.RestTemplate;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-
-import java.io.IOException;
-import java.util.Map;
-
 public class EventControllerTest {
-
+    
 
   @Test
   public void testEventTerms () throws IOException {
@@ -59,4 +61,6 @@ public class EventControllerTest {
     assertTrue( results.contains( "481" ));
     assertTrue( !results.contains( "ANXIETY" ));
   }
+  
+  
 }

--- a/src/test/java/com/nicusa/service/AdverseEffectsServiceIT.java
+++ b/src/test/java/com/nicusa/service/AdverseEffectsServiceIT.java
@@ -1,0 +1,47 @@
+package com.nicusa.service;
+
+import com.nicusa.PersistenceConfiguration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = PersistenceConfiguration.class)
+@EnableAutoConfiguration
+@ActiveProfiles("local")
+public class AdverseEffectsServiceIT
+{
+    Logger log = LoggerFactory.getLogger(AdverseEffectsServiceIT.class);
+
+    @PersistenceContext 
+    EntityManager entityManager;
+    
+    @Autowired
+    private AdverseEffectService adverseEffectService;
+
+    
+//    @Test
+//    public void testMerriamWebsterCall() throws IOException
+//    {
+//        RestTemplate rest = new RestTemplate();
+//        HttpSlurper slurp = new HttpSlurper();
+//        String val = "CEREBROVASCULAR ACCIDENT";
+//        String eval = URLEncoder.encode(val, "UTF-8");
+//        String s = slurp.getData("http://www.dictionaryapi.com/api/v1/references/medical/xml/"+eval+"?key=21a8b25b-2e1b-4969-9a28-d522f5782b26");
+//        if(s.contains("<dt>"))
+//        {
+//            String def = s.substring(s.indexOf("<dt>")+4, s.indexOf("</dt>"));
+//            System.out.println(def);
+//        }
+//    }
+}

--- a/src/test/java/com/nicusa/service/AdverseEffectsServiceTest.java
+++ b/src/test/java/com/nicusa/service/AdverseEffectsServiceTest.java
@@ -1,11 +1,13 @@
 package com.nicusa.service;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.junit.Assert.*;
 
 import com.nicusa.domain.AdverseEffectDescription;
+import com.nicusa.util.HttpSlurper;
 
 import java.util.ArrayList;
 
@@ -27,13 +29,20 @@ public class AdverseEffectsServiceTest
     {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         DocumentBuilder builder = factory.newDocumentBuilder();
+        HttpSlurper slurper = mock(HttpSlurper.class);
         EntityManager em = mock(EntityManager.class);
         Query q = mock(Query.class);
         when(em.createQuery(any(String.class))).thenReturn(q);
-        when(q.getResultList()).thenReturn(new ArrayList<AdverseEffectDescription>());
+        when(slurper.getData(anyString())).thenReturn(adverseEventXml1);
+        Query q2 = mock(Query.class);
+        when(q2.getResultList()).thenReturn(new ArrayList<AdverseEffectDescription>());
+        when(q.setParameter(anyString(), anyString())).thenReturn(q2);
         service = new AdverseEffectService();
         service.entityManager = em;
         service.documentBuilder = builder;
+        service.slurper = slurper;
+        service.merriamWebsterKey = "TestKey";
+        
     }
 
     @Test

--- a/src/test/java/com/nicusa/service/AdverseEffectsServiceTest.java
+++ b/src/test/java/com/nicusa/service/AdverseEffectsServiceTest.java
@@ -1,0 +1,53 @@
+package com.nicusa.service;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+
+import com.nicusa.domain.AdverseEffectDescription;
+
+import java.util.ArrayList;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class AdverseEffectsServiceTest
+{
+    AdverseEffectService service = null;
+
+    @Before
+    public void setup () throws Exception
+    {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        EntityManager em = mock(EntityManager.class);
+        Query q = mock(Query.class);
+        when(em.createQuery(any(String.class))).thenReturn(q);
+        when(q.getResultList()).thenReturn(new ArrayList<AdverseEffectDescription>());
+        service = new AdverseEffectService();
+        service.entityManager = em;
+        service.documentBuilder = builder;
+    }
+
+    @Test
+    public void testAdverseEffects () throws Exception
+    {
+        String description = service.findEffectDescription("RENAL");
+        
+        assertEquals("relating to, involving, affecting, or located in the region of the kidneys :nephric  renal function", description);
+    }
+
+    String adverseEventXml1 =
+            "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" +
+            "<entry_list version=\"1.0\">" +
+            "<entry id=\"renal\"><hw>re&#xB7;nal</hw><pr>ˈrēn-ᵊl</pr><sound><wav>renal001.wav</wav><wpr>!rE-n<up>u</up>l</wpr></sound><fl>adjective</fl><def><sensb><sens><dt>relating to, involving, affecting, or located in the region of the kidneys :<sx>nephric</sx>  <vi><it>renal</it> function</vi></dt></sens></sensb></def></entry>" +
+            "</entry_list>";
+
+}


### PR DESCRIPTION
I have added descriptions from definitions available from the Merriam Webster medical dictionary. If no definition is available for the given event I repeat the event (lowercased) in the description. If a successful attempt was made for the description then the description is saved in the database so we wont have to make the call out next time.

I have added the Merriam Webster key to the application.properties file. If the key is not available no attempt will be made to look up or cache the description.
